### PR TITLE
Add fullname and jid to contact's tooltip in roster

### DIFF
--- a/mockup/index.html
+++ b/mockup/index.html
@@ -143,7 +143,9 @@
                             <a href="#" data-group="Colleagues" class="group-toggle icon-opened" title="Click to hide these contacts">Colleagues</a>
                         </dt>
                         <dd class="online current-xmpp-contact">
-                            <a class="open-chat" title="Click to chat with this contact" href="#">
+                            <a class="open-chat" title="Name: Victor Matfield
+JID: victor.matfield@localhost
+Click to chat with this contact" href="#">
                                 <span class="icon-online" title="This contact is online"></span>
                                 Victor Matfield
                             </a>
@@ -215,7 +217,8 @@
                             <a href="#" class="group-toggle icon-opened" title="Click to hide these contacts">Contact Requests</a>
                         </dt>
                         <dd class="offline requesting-xmpp-contact">
-                            <span class="req-contact-name">Bob Skinstad</span>
+                            <span class="req-contact-name" title="Name: Bob Skinstad
+JID: bob.skinstad@localhost">Bob Skinstad</span>
                             <span class="request-actions">
                                 <a class="accept-xmpp-request icon-checkmark" title="Click here to accept this contact's request" href="#"></a>
                                 <a class="decline-xmpp-request icon-close" title="Click here to decline this contact's request" href="#"></a>
@@ -232,7 +235,8 @@
                         <dt id="pending-xmpp-contacts" style="display: block;">
                             <a href="#" class="group-toggle icon-opened" title="Click to hide these contacts">Pending Contacts</a>
                         </dt>
-                        <dd class="offline pending-xmpp-contact"><span class="pending-contact-name">Rassie Erasmus</span>
+                        <dd class="offline pending-xmpp-contact"><span class="pending-contact-name" title="Name: Rassie Erasmus
+JID: rassie.erasmus@localhost">Rassie Erasmus</span>
                             <a class="remove-xmpp-contact icon-remove" title="Click to remove this contact" href="#"></a>
                         </dd>
                         <dd class="offline pending-xmpp-contact"><span class="pending-contact-name">Victor Matfield</span>

--- a/spec/controlbox.js
+++ b/spec/controlbox.js
@@ -971,10 +971,15 @@
 
         describe("All Contacts", $.proxy(function () {
             beforeEach($.proxy(function () {
-                utils.clearBrowserStorage();
-                converse.rosterview.model.reset();
-                utils.createContacts('all').openControlBox();
-                utils.openContactsPanel();
+                runs(function () {
+                    utils.clearBrowserStorage();
+                    converse.rosterview.model.reset();
+                    utils.createContacts('all').openControlBox();
+                });
+                waits(50);
+                runs(function () {
+                    utils.openContactsPanel();
+                });
             }, converse));
 
             it("are saved to, and can be retrieved from, browserStorage", $.proxy(function () {
@@ -998,6 +1003,21 @@
                     expect(_.isEqual(new_attrs.sort(), old_attrs.sort())).toEqual(true);
                 }
             }, converse));
+            
+            it("will show fullname and jid properties on tooltip", $.proxy(function () {
+                var jid, name, i, t;
+                for (i=0; i<mock.cur_names.length; i++) {
+                    name = mock.cur_names[i];
+                    jid = name.replace(/ /g,'.').toLowerCase() + '@localhost';
+                    var $dd = this.rosterview.$el.find("dd:contains('"+name+"')").children().first();
+                    var dd_text = $dd.text();
+                    var dd_title = $dd.attr('title');
+                    expect(dd_text).toBe(name);
+                    expect(dd_title).toContain(name);
+                    expect(dd_title).toContain(jid);
+                }
+            }, converse));
+            
         }, converse));
     }, converse, mock, test_utils));
 

--- a/src/templates/pending_contact.html
+++ b/src/templates/pending_contact.html
@@ -1,1 +1,2 @@
-<span class="pending-contact-name">{{fullname}}</span> <a class="remove-xmpp-contact icon-remove" title="{{desc_remove}}" href="#"></a>
+<span class="pending-contact-name" title="Name: {{fullname}}
+JID: {{jid}}">{{fullname}}</span> <a class="remove-xmpp-contact icon-remove" title="{{desc_remove}}" href="#"></a>

--- a/src/templates/requesting_contact.html
+++ b/src/templates/requesting_contact.html
@@ -1,4 +1,5 @@
-<span class="req-contact-name">{{fullname}}</span>
+<span class="req-contact-name" title="Name: {{fullname}}
+JID: {{jid}}">{{fullname}}</span>
 <span class="request-actions">
     <a class="accept-xmpp-request icon-checkmark" title="{{desc_accept}}" href="#"></a>
     <a class="decline-xmpp-request icon-close" title="{{desc_decline}}" href="#"></a>

--- a/src/templates/roster_item.html
+++ b/src/templates/roster_item.html
@@ -1,2 +1,4 @@
-<a class="open-chat" title="{{desc_chat}}" href="#"><span class="icon-{{chat_status}}" title="{{desc_status}}"></span>{{fullname}}</a>
+<a class="open-chat" title="Name: {{fullname}}
+JID: {{jid}}
+{{desc_chat}}" href="#"><span class="icon-{{chat_status}}" title="{{desc_status}}"></span>{{fullname}}</a>
 <a class="remove-xmpp-contact icon-remove" title="{{desc_remove}}" href="#"></a>


### PR DESCRIPTION
It seems title attributes are limited to 512 chars, we will have
to live with that unless a custom tooltip is used.