### PR TITLE
Added new Makefile.win, it only has dev/build/check targets

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,4 +1,5 @@
 module.exports = function(grunt) {
+    var path = require('path');
     var cfg = require('./package.json');
     grunt.initConfig({
         jst: {
@@ -62,6 +63,10 @@ module.exports = function(grunt) {
                 dest: 'css/converse.min.css',
                 src: ['css/converse.css']
             }
+        },
+        touch: {
+            npm: ['stamp-npm'],
+            bower: ['stamp-bower']
         }
     });
     grunt.loadNpmTasks('grunt-contrib-cssmin');
@@ -69,6 +74,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-jst');
     grunt.loadNpmTasks('grunt-json');
     grunt.loadNpmTasks('grunt-contrib-requirejs');
+    grunt.loadNpmTasks('grunt-touch');
 
     grunt.registerTask('test', 'Run Tests', function () {
         var done = this.async();
@@ -107,23 +113,26 @@ module.exports = function(grunt) {
         var child_process = require('child_process');
         var exec = child_process.exec;
         var callback = function (err, stdout, stderr) {
+            grunt.log.write(stdout);
             if (err) {
                 grunt.log.write('build failed with error code '+err.code);
                 grunt.log.write(stderr);
-            }
-            grunt.log.write(stdout);
-            done();
+                done(false);
+            } else
+                done();
         };
-        exec('./node_modules/requirejs/bin/r.js -o src/build.js && ' +
-             './node_modules/requirejs/bin/r.js -o src/build.js optimize=none out=builds/converse.js && ' +
-             './node_modules/requirejs/bin/r.js -o src/build-no-jquery.js &&' +
-             './node_modules/requirejs/bin/r.js -o src/build-no-jquery.js optimize=none out=builds/converse.nojquery.js && ' +
-             './node_modules/requirejs/bin/r.js -o src/build-no-locales-no-otr.js && ' +
-             './node_modules/requirejs/bin/r.js -o src/build-no-locales-no-otr.js optimize=none out=builds/converse-no-locales-no-otr.js && ' +
-             './node_modules/requirejs/bin/r.js -o src/build-no-otr.js &&' +
-             './node_modules/requirejs/bin/r.js -o src/build-no-otr.js optimize=none out=builds/converse-no-otr.js && ' +
-             './node_modules/requirejs/bin/r.js -o src/build-website-no-otr.js &&' +
-             './node_modules/requirejs/bin/r.js -o src/build-website.js', callback);
+        var rjsext = (process.platform === 'win32') ? '.cmd' : '';
+        var rjs = path.resolve('./node_modules/.bin/r.js' + rjsext);
+        exec(rjs + ' -o src/build.js && ' +
+             rjs + ' -o src/build.js optimize=none out=builds/converse.js && ' +
+             rjs + ' -o src/build-no-jquery.js &&' +
+             rjs + ' -o src/build-no-jquery.js optimize=none out=builds/converse.nojquery.js && ' +
+             rjs + ' -o src/build-no-locales-no-otr.js && ' +
+             rjs + ' -o src/build-no-locales-no-otr.js optimize=none out=builds/converse-no-locales-no-otr.js && ' +
+             rjs + ' -o src/build-no-otr.js &&' +
+             rjs + ' -o src/build-no-otr.js optimize=none out=builds/converse-no-otr.js && ' +
+             rjs + ' -o src/build-website-no-otr.js &&' +
+             rjs + ' -o src/build-website.js', callback);
         // XXX: It might be possible to not have separate build config files. For example:
         // 'r.js -o src/build.js paths.converse-dependencies=src/deps-no-otr paths.locales=locale/nolocales out=builds/converse-no-locales-no-otr.min.js'
     });

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # You can set these variables from the command line.
+GRUNT   ?= node_modules/.bin/grunt
 BOWER           ?= node_modules/.bin/bower
 BUILDDIR     	= ./docs
 PAPER        	=
@@ -48,12 +49,6 @@ po2json:
 ########################################################################
 ## Release management
 
-jsmin:
-	./node_modules/requirejs/bin/r.js -o src/build.js && ./node_modules/requirejs/bin/r.js -o src/build-no-locales-no-otr.js && ./node_modules/requirejs/bin/r.js -o src/build-no-otr.js && ./node_modules/requirejs/bin/r.js -o src/build-website.js
-
-cssmin:
-	grunt cssmin
-
 release:
 	sed -i s/Project-Id-Version:\ Converse\.js\ [0-9]\.[0-9]\.[0-9]/Project-Id-Version:\ Converse.js\ $(VERSION)/ locale/converse.pot
 	sed -i s/\"version\":\ \"[0-9]\.[0-9]\.[0-9]\"/\"version\":\ \"$(VERSION)\"/ bower.json
@@ -85,18 +80,18 @@ clean::
 
 dev: clean
 	npm install
-	${BOWER} update;
+	$(BOWER) update;
 	bundler install --path=.
 
 ########################################################################
 ## Builds
 
 css::
-	${SASS} sass/converse.scss > css/converse.css
+	$(SASS) sass/converse.scss > css/converse.css
 
 build::
-	./node_modules/.bin/grunt jst
-	./node_modules/.bin/grunt minify
+	$(GRUNT) jst
+	$(GRUNT) minify
 
 ########################################################################
 ## Tests

--- a/Makefile.win
+++ b/Makefile.win
@@ -1,0 +1,55 @@
+# You can set these variables from the command line.
+GRUNT   ?= node_modules\.bin\grunt.cmd
+BOWER           ?= node_modules\.bin\bower
+PHANTOMJS       ?= node_modules\.bin\phantomjs
+SASS 			?= sass 
+RMRF ?= rmdir /q /s 
+RMF ?= del /q 
+
+.PHONY: all help clean css minjs build
+
+all: dev
+
+help:
+	@echo "Please use \`make <target>' where <target> is one of"
+	@echo "  dev        to set up the development environment"
+	@echo "  build      create minified builds containing converse.js and all its dependencies"
+
+########################################################################
+## Install dependencies
+
+stamp-npm: package.json
+	npm install
+    $(GRUNT) touch:npm
+
+stamp-bower: stamp-npm bower.json
+	$(BOWER) install
+	$(GRUNT) touch:bower
+
+clean::
+	@if EXIST stamp-npm $(RMF) stamp-npm
+	@if EXIST stamp-bower $(RMF) stamp-bower
+	@if EXIST node_modules\. $(RMRF) node_modules
+	@if EXIST components\. $(RMRF) components
+
+dev: clean
+	npm install
+	$(BOWER) update
+    bundler install --path=.
+
+########################################################################
+## Builds
+
+css::
+	$(SASS) sass/converse.scss > css/converse.css
+
+build::
+	$(GRUNT) jst
+	$(GRUNT) minify
+
+########################################################################
+## Tests
+
+check:: stamp-npm
+	$(PHANTOMJS) node_modules/phantom-jasmine/lib/run_jasmine_test.coffee tests.html
+

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -12,6 +12,7 @@ Changelog
 * #292 Better support for XEP-0085 Chat State Notifications. [jcbrand]
 * #295 Document "allow_registration". [gbonvehi]
 * #304 Added Polish translations. [ser]
+* New Makefile.win to build in Windows environments. [gbonvehi]
 
 0.8.6 (2014-12-07)
 ------------------

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -12,6 +12,8 @@ follow the instructions below to create this folder and fetch Converse's
 3rd-party dependencies.
 
 .. note::
+    Windows environment: We recommend installing the required tools using `Chocolatey <https://chocolatey.org/>`_
+    You will need Node.js (nodejs.install), Git (git.install) and optionally to build using Makefile, GNU Make (make)
     If you have trouble setting up a development environment on Windows,
     please read `this post <http://librelist.com/browser//conversejs/2014/11/5/openfire-converse-and-visual-studio-questions/#b28387e7f8f126693b11598a8acbe810>`_
     in the mailing list.:
@@ -27,6 +29,9 @@ version `here <https://nodejs.org/download>`_.
 
 Also make sure you have ``Git`` installed. `Details <http://git-scm.com/book/en/Getting-Started-Installing-Git>`_.
 
+.. note::
+    Windows users should use Chocolatey as recommended above.:
+
 Once you have *Node.js* and *git* installed, run the following command inside the Converse.js
 directory:
 
@@ -34,13 +39,18 @@ directory:
 
     make dev
 
+On Windows you need to specify Makefile.win to be used by running:
+    
+::
+    make -f Makefile.win dev
+    
 Or alternatively, if you don't have GNU Make:
 
 ::
 
     npm install
     bower update
-
+    
 This will first install the Node.js development tools (like Grunt and Bower)
 and then use Bower to install all of Converse.js's front-end dependencies.
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "grunt-contrib-jst": "~0.6.0",
     "grunt-contrib-requirejs": "~0.4.3",
     "grunt-json": "^0.1.3",
+    "grunt-touch": "^0.1.0",
     "less": "~1.7.0",
     "phantom-jasmine": "0.1.8",
     "phantomjs": "~1.9.7-1",


### PR DESCRIPTION
Gruntfile now appends .cmd extension to r.js if platform is win32
Made touch-npm/bower grunt task/targets to be multiplatform (depends on node/grunt)
make -f Makefile.win to build on Windows

This is PR #301 with docs added and moved to a new branch.