### PR TITLE
Strophe.log and .error now calls converse.log, this honors converse.debu...

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -163,8 +163,8 @@
         var converse = this;
 
         // Logging
-        Strophe.log = function (level, msg) { console.log(level+' '+msg); };
-        Strophe.error = function (msg) { console.log('ERROR: '+msg); };
+        Strophe.log = function (level, msg) { converse.log(level+' '+msg, level); };
+        Strophe.error = function (msg) { converse.log(msg, 'error'); };
 
         // Add Strophe Namespaces
         Strophe.addNamespace('CHATSTATES', 'http://jabber.org/protocol/chatstates');

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -13,6 +13,7 @@ Changelog
 * #295 Document "allow_registration". [gbonvehi]
 * #304 Added Polish translations. [ser]
 * New Makefile.win to build in Windows environments. [gbonvehi]
+* Strophe.log and Strophe.error now uses converse.log to output messages. [gbonvehi]
 
 0.8.6 (2014-12-07)
 ------------------


### PR DESCRIPTION
Currently converse.js is very verbose as Strophe.log is called everywhere and it simply outputs the content to console even if converse.debug === false