### PR TITLE
Hide 'Server' Label when hiding server input

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -1760,6 +1760,7 @@
                     this.$el.html(
                         converse.templates.room_panel({
                             'server_input_type': converse.hide_muc_server && 'hidden' || 'text',
+                            'server_label_global_attr': converse.hide_muc_server && ' hidden' || '',
                             'label_room_name': __('Room name'),
                             'label_nickname': __('Nickname'),
                             'label_server': __('Server'),

--- a/src/templates/room_panel.html
+++ b/src/templates/room_panel.html
@@ -5,7 +5,7 @@
     <label>{{label_nickname}}</label>
     <input type="text" name="nick" class="new-chatroom-nick"
         placeholder="{{label_nickname}}"/>
-    <label>{{label_server}}</label>
+    <label{{server_label_global_attr}}>{{label_server}}</label>
     <input type="{{server_input_type}}" name="server" class="new-chatroom-server"
         placeholder="{{label_server}}"/>
     <div class="button-group">


### PR DESCRIPTION
hide_muc_server hides the input box but not the 'Server' label.
Of course, it's possible to patch the css for this purpose, but the gui should conform to the hide_muc_server directive.

Note : I didn't test it as I don't have time to setup a build environnement, but the change is simple enough.