### PR TITLE
Fix the plugin extend function

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -5587,7 +5587,7 @@
                     if (key === 'events') {
                         obj.prototype[key] = _.extend(value, obj.prototype[key]);
                     } else {
-                        if (typeof key === 'function') {
+                        if (typeof value === 'function') {
                             obj.prototype._super[key] = obj.prototype[key];
                         }
                         obj.prototype[key] = value;


### PR DESCRIPTION
I tried to use the `converse.plugins.extend` function but there was a bug. To check if a function was been added to the extended object, a `typeof key ===  'function'` was tested instead of `typeof value === 'function'`.