### PR TITLE
Fix the ChatRoomOccupants storage id

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -2188,11 +2188,7 @@
         });
 
         this.ChatRoomOccupants = Backbone.Collection.extend({
-            model: converse.ChatRoomOccupant,
-            initialize: function (options) {
-                this.browserStorage = new Backbone.BrowserStorage[converse.storage](
-                    b64_sha1('converse.occupants'+converse.bare_jid+options.nick));
-            }
+            model: converse.ChatRoomOccupant
         });
 
         this.ChatRoomOccupantsView = Backbone.Overview.extend({
@@ -2350,6 +2346,10 @@
                 this.occupantsview = new converse.ChatRoomOccupantsView({
                     model: new converse.ChatRoomOccupants({nick: this.model.get('nick')})
                 });
+                var id =  b64_sha1('converse.occupants'+converse.bare_jid+this.model.get('id')+this.model.get('nick'));
+                this.occupantsview.model.id = id; // Appears to be necessary for backbone.browserStorage
+                this.occupantsview.model.browserStorage = new Backbone.BrowserStorage[converse.storage](id);
+
                 this.occupantsview.chatroomview = this;
                 this.render();
                 this.occupantsview.model.fetch({add:true});


### PR DESCRIPTION
The storage id generated for the occupants of a chat room is the same for all chat rooms. The results is that all chat rooms fetches the same data and all chat rooms appear to have the same occupants.

This is fixed by adding the room jid in the generated id.