### PR TITLE
Fix a timeout bug in chat state notifications

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -1243,12 +1243,11 @@
                  *    (string) state - The chat state (consts ACTIVE, COMPOSING, PAUSED, INACTIVE, GONE)
                  *    (no_save) no_save - Just do the cleanup or setup but don't actually save the state.
                  */
-                if (_.contains([ACTIVE, INACTIVE, GONE], state)) {
-                    if (typeof this.chat_state_timeout !== 'undefined') {
-                        clearTimeout(this.chat_state_timeout);
-                        delete this.chat_state_timeout;
-                    }
-                } else if (state === COMPOSING) {
+                if (typeof this.chat_state_timeout !== 'undefined') {
+                    clearTimeout(this.chat_state_timeout);
+                    delete this.chat_state_timeout;
+                }
+                if (state === COMPOSING) {
                     this.chat_state_timeout = setTimeout(
                             $.proxy(this.setChatState, this), converse.TIMEOUTS.PAUSED, PAUSED);
                 } else if (state === PAUSED) {


### PR DESCRIPTION
Issues:
 - when composing without interruption during a long time (longer than TIMEOUT.PAUSED), a `<paused>` state is sent. 
 - after sending a message and after TIMEOUT.PAUSED, a `<paused>` state is sent.

These `<paused>` states shouldn't be sent. This bug comes from timeouts that are not correctly managed.

```
if (_.contains([ACTIVE, INACTIVE, GONE], state)) {
    if (typeof this.chat_state_timeout !== 'undefined') {
        clearTimeout(this.chat_state_timeout);
        delete this.chat_state_timeout;
    }
} else if (state === COMPOSING) {
    this.chat_state_timeout = setTimeout(
            $.proxy(this.setChatState, this), converse.TIMEOUTS.PAUSED, PAUSED);
} else if (state === PAUSED) {
    this.chat_state_timeout = setTimeout(
            $.proxy(this.setChatState, this), converse.TIMEOUTS.INACTIVE, INACTIVE);
}
```

When typing several letters, the `state === COMPOSING ` branch is visited each time, and it starts a new timeout each time without clearing the previous one. 

The fix is simple: always clear the previous timeout, no matter the state.
