### PR TITLE
Fixed an error that appears when unload event is triggered

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -569,10 +569,13 @@
         };
 
         this.clearSession = function () {
-            this.roster.browserStorage._clear();
+            if (this.roster) {
+                this.roster.browserStorage._clear();
+            }
             this.session.browserStorage._clear();
-            var controlbox = converse.chatboxes.get('controlbox');
-            controlbox.save({'connected': false});
+            if (converse.connection.connected) {
+                converse.chatboxes.get('controlbox').save({'connected': false});
+            }
         };
 
         this.setSession = function () {

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Refactored in order to remove the strophe.roster.js dependency. [jcbrand]
 * Bugfix. Manual login doesn't work when only websocket_url is set and not bosh_service_url. [jcbrand]
+* Bugfix. clearSessions during unload event would throw an error when not logged in. [gbonvehi]
 
 0.9.3 (2015-05-01)
 ------------------


### PR DESCRIPTION
This happens when you load a page with converse and do not login to
the chat. It can be tested in converse.org preserving logs while
navigating to another page.
Inside clearSession there's a call to roster which is not initalized
and also another one to controlbox.save which is not set so it fails
with an url error during sync.