### PR TITLE
Added login-panel placeholder and roster-item Name translations

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -3686,6 +3686,7 @@
                             'desc_status': STATUSES[chat_status||'offline'],
                             'desc_chat': __('Click to chat with this contact'),
                             'desc_remove': __('Click to remove this contact'),
+                            'title_fullname': __('Name'),
                             'allow_contact_removal': converse.allow_contact_removal
                         })
                     ));
@@ -5333,7 +5334,9 @@
                         'label_username': __('XMPP Username:'),
                         'label_password': __('Password:'),
                         'label_anon_login': __('Click here to log in anonymously'),
-                        'label_login': __('Log In')
+                        'label_login': __('Log In'),
+                        'placeholder_username': __('user@server'),
+                        'placeholder_password': __('password')
                     })
                 ));
                 this.$tabs = cfg.$parent.parent().find('#controlbox-tabs');

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -7,6 +7,7 @@ Changelog
 * Refactored in order to remove the strophe.roster.js dependency. [jcbrand]
 * Bugfix. Manual login doesn't work when only websocket_url is set and not bosh_service_url. [jcbrand]
 * Bugfix. clearSessions during unload event would throw an error when not logged in. [gbonvehi]
+* #389 Allow login panel placeholders and roster item 'Name' translations. [gbonvehi]
 
 0.9.3 (2015-05-01)
 ------------------

--- a/src/templates/login_panel.html
+++ b/src/templates/login_panel.html
@@ -5,9 +5,9 @@
     {[ if (!auto_login) { ]}
         {[ if (authentication == LOGIN) { ]}
             <label>{{label_username}}</label>
-            <input name="jid" placeholder="user@server">
+            <input name="jid" placeholder="{{placeholder_username}}">
             <label>{{label_password}}</label>
-            <input type="password" name="password" placeholder="password">
+            <input type="password" name="password" placeholder="{{placeholder_password}}">
             <input class="submit" type="submit" value="{{label_login}}">
             <span class="conn-feedback"></span>
         {[ } ]}

--- a/src/templates/roster_item.html
+++ b/src/templates/roster_item.html
@@ -1,4 +1,4 @@
-<a class="open-chat" title="Name: {{fullname}}
+<a class="open-chat" title="{{title_fullname}}: {{fullname}}
 JID: {{jid}}
 {{desc_chat}}" href="#"><span class="icon-{{chat_status}}" title="{{desc_status}}"></span>{{fullname}}</a>
 {[ if (allow_contact_removal) { ]}


### PR DESCRIPTION
This will allow to translate 'user@server' and 'password' in the login
screen and also in the roster-item tooltip, there's 'Name:' which can
now be translated