### PR TITLE
Language Detection

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -215,7 +215,32 @@
 
         // Translation machinery
         // ---------------------
-        this.i18n = settings.i18n ? settings.i18n : locales.en;
+		 this.isAvailableLocale=function(locale){
+            ret=null;
+            if (locales[locale]) ret=locales[locale];
+            else{
+                sublocale=locale.split("-")[0];
+                if (sublocale!=locale && locales[sublocale]) ret=locales[sublocale];
+            }
+            return ret;
+        };
+		
+        this.detectLocale=function(){
+            ret=null;
+            if (window.navigator.userLanguage) ret=this.isAvailableLocale(window.navigator.userLanguage);
+            else if (window.navigator.languages && !ret){
+                for (var i = 0; i < window.navigator.languages.length && !ret; i++) {
+                 ret=this.isAvailableLocale(window.navigator.languages[i]);
+                }
+            }
+            else if (window.navigator.browserLanguage && !ret) ret=this.isAvailableLocale(window.navigator.browserLanguage);
+            else if (window.navigator.language && !ret) ret=this.isAvailableLocale(window.navigator.language);
+            else if (window.navigator.systemLanguage && !ret) ret=this.isAvailableLocale(window.navigator.systemLanguage);
+            else {ret=locales.en}
+            return ret;
+        };
+
+        this.i18n = settings.i18n ? settings.i18n : this.detectLocale();
         var __ = $.proxy(utils.__, this);
         var ___ = utils.___;
 

--- a/converse.js
+++ b/converse.js
@@ -215,7 +215,7 @@
 
         // Translation machinery
         // ---------------------
-		 this.isAvailableLocale=function(locale){
+	this.isAvailableLocale=function(locale){
             ret=null;
             if (locales[locale]) ret=locales[locale];
             else{

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 * Bugfix. Manual login doesn't work when only websocket_url is set and not bosh_service_url. [jcbrand]
 * Bugfix. clearSessions during unload event would throw an error when not logged in. [gbonvehi]
 * #389 Allow login panel placeholders and roster item 'Name' translations. [gbonvehi]
+* I18N: Autodetection of User Locale if no i18n setting is set. [thierrytiti]
 
 0.9.3 (2015-05-01)
 ------------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -360,6 +360,9 @@ If set to ``true``, then don't show offline users.
 i18n
 ----
 
+* Default:  Auto-detection of the User/Browser language
+
+If no locale is matching available locales, the default is ``en``.
 Specify the locale/language. The language must be in the ``locales`` object. Refer to
 ``./locale/locales.js`` to see which locales are supported.
 


### PR DESCRIPTION
Replace default language to autodetection if no i18n setting is set.

Add autodetection of the user language
default to locales.en if no matching found