### PR TITLE
add .cmd extensions to makefile.win

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -1,11 +1,11 @@
 # You can set these variables from the command line.
 GRUNT   		?= node_modules\.bin\grunt.cmd
-BOWER           ?= node_modules\.bin\bower
-PHANTOMJS       ?= node_modules\.bin\phantomjs
+BOWER                   ?= node_modules\.bin\bower.cmd
+PHANTOMJS               ?= node_modules\.bin\phantomjs.cmd
 SASS 			?= sass 
 RMRF 			?= rmdir /q /s 
 RMF 			?= del /q 
-HTTPSERVE		?= ./node_modules/.bin/http-server
+HTTPSERVE		?= ./node_modules/.bin/http-server.cmd
 
 .PHONY: all help clean css minjs build
 


### PR DESCRIPTION
I was getting the following error while running make all on my windows machine
"""
node_modules/.bin/bower install
'node_modules' is not recognized as an internal or external command,
operable program or batch file.
make: *** [stamp-bower] Error 1
"""

This was resolved by adding the complete extension to the windows path.