### PR TITLE
Excessive double quote in french translation file

### DIFF
--- a/locale/fr/LC_MESSAGES/converse.po
+++ b/locale/fr/LC_MESSAGES/converse.po
@@ -282,7 +282,7 @@ msgstr "Vos messges ne sont pas cryptés. Cliquez ici pour activer le cryptage O
 
 #: converse.js:1554
 msgid "Your messages are encrypted, but your contact has not been verified."
-msgstr "Vos messges sont cryptés, mais votre contact n'a pas été vérifié""
+msgstr "Vos messges sont cryptés, mais votre contact n'a pas été vérifié"
 
 #: converse.js:1556
 msgid "Your messages are encrypted and your contact verified."


### PR DESCRIPTION
Excessive double quote in ./locale/fr/LC_MESSAGES/converse.po caused "make po" to fail:

./locale/fr/LC_MESSAGES/converse.po:286: end-of-line within string