### PR TITLE
Fix no messages being shown in chat 

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -1384,7 +1384,7 @@
                 var $first_msg = this.$content.children('.chat-message:first'),
                     first_msg_date = $first_msg.data('isodate'),
                     last_msg_date, current_msg_date, day_date, $msgs, msg_dates, idx;
-                if (typeof first_msg_date === "undefined") {
+                if (!first_msg_date) {
                     this.appendMessage(attrs);
                     return;
                 }


### PR DESCRIPTION
Hey,

when upgrading my custom built version 0.9.3 to the current 0.9.5 (in order to use the new message archiving feature) converse stopped displaying any (sent and received) messages in the chat views.
When debugging the code, I found `first_msg_date` to be `null` and therefore the code trying to determine the insert position did nothing.

The situation is fixed in my PR by handling both `undefined` and `null` correctly.
I don't know why I get `null` from `$first_msg.data('isodate')` when you were getting `undefined`, maybe it is related to me receiving archived messages or using a slightly different jQuery version (1.10.2).

Cheers!