### PR TITLE
Fix #461: MUC working with spaces etc. in room names

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -2319,15 +2319,16 @@
                 else { $nick.removeClass('error'); }
 
                 if (ev.type === 'click') {
+                    name = $(ev.target).text();
                     jid = $(ev.target).attr('data-room-jid');
                 } else {
                     $name = this.$el.find('input.new-chatroom-name');
                     $server= this.$el.find('input.new-chatroom-server');
                     server = $server.val();
-                    name = $name.val().trim().toLowerCase();
+                    name = $name.val().trim();
                     $name.val(''); // Clear the input
                     if (name && server) {
-                        jid = Strophe.escapeNode(name) + '@' + server;
+                        jid = Strophe.escapeNode(name.toLowerCase()) + '@' + server;
                         $name.removeClass('error');
                         $server.removeClass('error');
                         this.model.save({muc_domain: server});
@@ -2341,7 +2342,7 @@
                 chatroom = converse.chatboxviews.showChat({
                     'id': jid,
                     'jid': jid,
-                    'name': Strophe.unescapeNode(Strophe.getNodeFromJid(jid)),
+                    'name': name || Strophe.unescapeNode(Strophe.getNodeFromJid(jid)),
                     'nick': nick,
                     'chatroom': true,
                     'box_id' : b64_sha1(jid)
@@ -3009,7 +3010,7 @@
             getRoomJIDAndNick: function (nick) {
                 nick = nick || this.model.get('nick');
                 var room = this.model.get('jid');
-                var node = Strophe.escapeNode(Strophe.getNodeFromJid(room));
+                var node = Strophe.getNodeFromJid(room);
                 var domain = Strophe.getDomainFromJid(room);
                 return node + "@" + domain + (nick !== null ? "/" + nick : "");
             },

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -9,6 +9,7 @@ Changelog
 * #440 null added as resource to contact [jcbrand]
 * Add new event serviceDiscovered [jcbrand]
 * Add a new configuration setting `muc_history_max_stanzas <https://conversejs.org/docs/html/configuration.html#muc_history_max_stanzas>`_. [jcbrand]
+* #462 Fix MUC rooms with names containing special characters not working [1st8]
 
 0.9.4 (2015-07-04)
 ------------------

--- a/src/templates/chatroom.html
+++ b/src/templates/chatroom.html
@@ -5,7 +5,7 @@
         <a class="close-chatbox-button icon-close"></a>
         <a class="toggle-chatbox-button icon-minus"></a>
         <a class="configure-chatroom-button icon-wrench" style="display:none"></a>
-        <div class="chat-title"> {{ name }} </div>
+        <div class="chat-title"> {{ _.escape(name) }} </div>
         <p class="chatroom-topic"><p/>
     </div>
     <div class="chat-body"><span class="spinner centered"/></div>

--- a/src/templates/room_item.html
+++ b/src/templates/room_item.html
@@ -1,6 +1,6 @@
 <dd class="available-chatroom">
 <a class="open-room" data-room-jid="{{jid}}"
-   title="{{open_title}}" href="#">{{name}}</a>
+   title="{{open_title}}" href="#">{{_.escape(name)}}</a>
 <a class="room-info icon-room-info" data-room-jid="{{jid}}"
    title="{{info_title}}" href="#">&nbsp;</a>
 </dd>


### PR DESCRIPTION
Rooms with bullshit in name now working, yay!
Next: Submit `muc#roomconfig_roomname` on creation to persist full name on server.

![bildschirmfoto 2015-09-03 um 16 20 23](https://cloud.githubusercontent.com/assets/646693/9660834/fddf305c-5257-11e5-86e4-47aef5043505.png)