### PR TITLE
Fix [object Object] being sometimes shown as status

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -4457,7 +4457,7 @@
                     if ((converse.connection.jid !== jid)&&(presence_type !== 'unavailable')) {
                         // Another resource has changed its status, we'll update ours as well.
                         converse.xmppstatus.save({'status': chat_status});
-                        if (status_message.length) { converse.xmppstatus.save({'status_message': status_message}); }
+                        if (status_message.length) { converse.xmppstatus.save({'status_message': status_message.text()}); }
                     }
                     return;
                 } else if (($presence.find('x').attr('xmlns') || '').indexOf(Strophe.NS.MUC) === 0) {

--- a/docs/CHANGES.rst
+++ b/docs/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 * #462 Fix MUC rooms with names containing special characters not working [1st8]
+* #468 Fix [object Object] being sometimes shown as status [1st8]
 
 0.9.5 (2015-08-24)
 ------------------


### PR DESCRIPTION
Fix [object Object] being shown as status when presence stanza with custom 'status' is received from other resource.

Cheers!