### PR TITLE
Auto join on invite patch 1 (auto_join_on_invite new parameter)

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -304,6 +304,7 @@
             auto_login: false, // Currently only used in connection with anonymous login
             auto_reconnect: false,
             auto_subscribe: false,
+            auto_join_on_invite: false,                     // Auto-join chatroom on invite
             bosh_service_url: undefined, // The BOSH connection manager URL.
             cache_otr_key: false,
             csi_waiting_time: 0, // Support for XEP-0352. Seconds before client is considered idle and CSI is sent out.
@@ -3633,15 +3634,19 @@
                     contact = converse.roster.get(from),
                     result;
 
-                if (!reason) {
-                    result = confirm(
-                        __(___("%1$s has invited you to join a chat room: %2$s"), contact.get('fullname'), room_jid)
-                    );
+                if (converse.auto_join_on_invite) {
+                    result = true;
                 } else {
-                    result = confirm(
-                         __(___('%1$s has invited you to join a chat room: %2$s, and left the following reason: "%3$s"'),
-                                contact.get('fullname'), room_jid, reason)
-                    );
+                    contact = contact? contact.get('fullname'): Strophe.getNodeFromJid(from);   // Invite request might come from someone not your roster list
+                    if (!reason) {
+                        result = confirm(
+                            __(___("%1$s has invited you to join a chat room: %2$s"), contact, room_jid)
+                        );
+                    } else {
+                        result = confirm(
+                             __(___('%1$s has invited you to join a chat room: %2$s, and left the following reason: "%3$s"'), contact, room_jid, reason)
+                        );
+                    }
                 }
                 if (result === true) {
                     var chatroom = converse.chatboxviews.showChat({

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.10.1 (2015-12-02)
+
+- #524 Added auto_join_on_invite parameter for automatically joining chatrooms. [ben]
+- FIX: A chatroom invite might come from someone not in your roster list. [ben]
+
 ## 0.10.0 (2015-11-05)
 
 **Note:**
@@ -15,6 +20,7 @@
 - #510 MUC room memberlist is being cleared with page reload when keepalive option is set. [jcbrand]
 - Add the ability to also drag-resize chat boxes horizontally. [jcbrand]
 - Updated Sass files and created a new style. [jcbrand]
+
 
 ## 0.9.6 (2015-10-12)
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -244,6 +244,13 @@ auto_subscribe
 
 If true, the user will automatically subscribe back to any contact requests.
 
+auto_join_on_invite
+--------------
+
+* Default:  ``false``
+
+If true, the user will automatically join a chatroom on invite without any confirm.
+
 .. _`bosh-service-url`:
 
 bosh_service_url


### PR DESCRIPTION
As planned on issue #524 I have added this new parameter.
Minor fix: fixed confirm() dialog box when a request comes from someone not in your roster list