### PR TITLE
no-otr compilation issue: Utils is not defined

### DIFF
--- a/src/deps-no-otr.js
+++ b/src/deps-no-otr.js
@@ -1,8 +1,8 @@
 define("converse-dependencies", [
     "jquery",
     "underscore",
-    "utils",
     "polyfill",
+    "utils",
     "moment_with_locales",
     "strophe",
     "strophe.disco",


### PR DESCRIPTION
I had problems in the no-otr compilation.  I had to change the order of the parameters in this file.