### PR TITLE
Bumped version to fix mismatch

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "converse.js",
   "description": "Web-based XMPP/Jabber chat client written in javascript",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "MPL-2.0",
   "devDependencies": {
     "jasmine": "https://github.com/jcbrand/jasmine.git#1_3_x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "converse.js",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Browser based XMPP instant messaging client",
   "main": "main.js",
   "directories": {


### PR DESCRIPTION
Fixed:
```
bower converse#*              mismatch Version declared in the json (0.10.0) is different than the resolved one (0.10.1)
```