### PR TITLE
Fix for issue #261

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -2555,6 +2555,9 @@
                 if (this.model.get('connected')) {
                     this.initRoster();
                 }
+                if (typeof this.model.get('closed')==='undefined') {
+                    this.model.set('closed', !converse.show_controlbox_by_default);
+                }
                 if (!this.model.get('closed')) {
                     this.show();
                 } else {

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.10.2 (Unreleased)
 
+- #261 show_controlbox_by_default config not working [diditopher]
 - #573 xgettext build error: `'javascript' unknown`
 
 ## 0.10.1 (2016-02-06)


### PR DESCRIPTION
When converse is first initialized `this.model.get('closed')` is undefined, at least with some configurations. This patch initializes the attribute with `!show_controlbox_by_default` if it is undefined.