### PR TITLE
Keep scroll position on minimize/maximize

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -2037,6 +2037,7 @@
                      */
                     chatboxviews.trimChats(this);
                     converse.refreshWebkit();
+                    this.$content.scrollTop(this.model.get('scroll'));
                     this.setChatState(ACTIVE).focus();
                     converse.emit('chatBoxMaximized', this);
                 }.bind(this));
@@ -2044,6 +2045,8 @@
 
             minimize: function (ev) {
                 if (ev && ev.preventDefault) { ev.preventDefault(); }
+                // save the scroll position to restore it on maximize
+                this.model.save({'scroll': this.$content.scrollTop()});
                 // Minimizes a chat box
                 this.setChatState(INACTIVE).model.minimize();
                 this.$el.hide('fast', converse.refreshwebkit);

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -4,6 +4,7 @@
 
 - #261 show_controlbox_by_default config not working [diditopher]
 - #573 xgettext build error: `'javascript' unknown`
+- Save scroll position on minimize and restore it on maximize [rlanvin]
 
 ## 0.10.1 (2016-02-06)
 


### PR DESCRIPTION
When a chatbox is minimized and maximized, the scroll bar jumps back at the top of the conversation, forcing the user to scroll down again.

This pull request saves the position of the scroll bar on minimize, and restore it on maximize.