### PR TITLE
Don't steal focus when chatbox is opened automatically

### DIFF
--- a/converse.js
+++ b/converse.js
@@ -2174,22 +2174,22 @@
                 return this;
             },
 
-            show: function (callback) {
+            show: function (focus) {
                 if (this.$el.is(':visible') && this.$el.css('opacity') === "1") {
                     return this.focus();
                 }
                 this.initDragResize().setDimensions();
                 this.$el.fadeIn(function () {
-                    if (typeof callback === "function") {
-                        callback.apply(this, arguments);
-                    }
                     if (converse.connection.connected) {
                         // Without a connection, we haven't yet initialized
                         // localstorage
                         this.model.save();
                     }
                     this.setChatState(ACTIVE);
-                    this.scrollDown().focus();
+                    this.scrollDown();
+                    if ( focus ) {
+                        this.focus();
+                    }
                 }.bind(this));
                 return this;
             },
@@ -3923,7 +3923,7 @@
                 if (chatbox.get('minimized')) {
                     chatbox.maximize();
                 } else {
-                    chatbox.trigger('show');
+                    chatbox.trigger('show', true);
                 }
                 return chatbox;
             }

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -5,6 +5,7 @@
 - #261 show_controlbox_by_default config not working [diditopher]
 - #573 xgettext build error: `'javascript' unknown`
 - Save scroll position on minimize and restore it on maximize [rlanvin]
+- #566 Do not steal the focus when the chatbox opens automatically [rlanvin]
 
 ## 0.10.1 (2016-02-06)
 


### PR DESCRIPTION
This is an attempt (probably a bit ugly) to fix the problem described in #566 - when somebody talks to you, the opening chatbox steals the focus, which is extremely annoying.

Here is a quick explanation:

I noticed that the focus is happening in `ChatBoxView.show`, so I disabled it from here. However it's good to focus when the user open the chatbox manually. I noticed that when the chatbox is opened by a click from the user, the execution flows first through `ChatBoxViews.showChat`. Unfortunately from here I didn't find anyway to call `focus`... so instead I made this method trigger the `show` event with a parameter `focus` set to `true`. I'm not sure what the `callback` parameter was used for, so I left it intact. There is probably a cleaner way to pass the parameter to the event.