### PR TITLE
Csp compat

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,7 @@
 - New event ['rosterContactsFetched'](https://conversejs.org/docs/html/development.html#rosterContactsFetched) [jcbrand]
 - New event ['rosterGroupsFetched'](https://conversejs.org/docs/html/development.html#rosterGroupsFetched) [jcbrand]
 - HTML templates are now loaded in the respective modules/plugins. [jcbrand]
+- Start improving Content-Security-Policy compatibility by removing inline CSS.
 
 ## 2.0.0 (2016-09-16)
 - #656 Online users count not shown initially [amanzur]

--- a/sass/_controlbox.scss
+++ b/sass/_controlbox.scss
@@ -201,6 +201,12 @@
                     }
                 }
             }
+
+            /* Custom addition for CSP */
+            dd.search-xmpp {
+                display: none;
+            }
+
             dd.search-xmpp ul {
                 box-shadow: 1px 4px 10px 1px rgba(0, 0, 0, 0.4);
                 li:hover {

--- a/sass/_roster.scss
+++ b/sass/_roster.scss
@@ -13,6 +13,11 @@
         height: calc(100% - #{$controlbox-dropdown-height} - 20px);
     }
 
+    /* Custom addition for CSP */
+    #online-count {
+        display: none;
+    }
+
     .search-xmpp {
         ul {
             li.chat-info {

--- a/src/templates/add_contact_dropdown.html
+++ b/src/templates/add_contact_dropdown.html
@@ -2,5 +2,5 @@
     <dt id="xmpp-contact-search" class="fancy-dropdown">
         <a class="toggle-xmpp-contact-form icon-plus" href="#" title="{{label_click_to_chat}}"> {{label_add_contact}}</a>
     </dt>
-    <dd class="search-xmpp" style="display:none"><ul></ul></dd>
+    <dd class="search-xmpp"><ul></ul></dd>
 </dl>

--- a/src/templates/controlbox_toggle.html
+++ b/src/templates/controlbox_toggle.html
@@ -1,2 +1,2 @@
 <span class="conn-feedback">{{label_toggle}}</span>
-<span style="display: none" id="online-count">(0)</span>
+<span id="online-count">(0)</span>


### PR DESCRIPTION
I am attempting to use Converse.js as a webclient for https://jabber.at. But we use [Content Security Policy](https://en.wikipedia.org/wiki/Content_Security_Policy) headers to protect us against any XSS attacks. Converse.js uses inline CSS in a few places, which is ignored on our page due to the CSP header.

This pull request replaces some minor inline CSS with CSS styles. This would improve compatibility with CSP headers at least far enough that users can log in, the roster works and chatting works. More work would need to be done, but I thought I'd start with something small. I'm willing to put further work into this if you are interested and we can get this merged.

There is a test that fails with these changes, ``spec/protocol.js:82`` and ``spec/protocol.js:86``, but manually testing reveals no display errors. [This stackoverflow ticket](http://stackoverflow.com/a/8337382) seems to imply that jQuery's `is(":visible")` check could be at fault. I do not know the system well enough to say for sure if that's true or if I actually broke anything.