### PR TITLE
Render all drag resize handles in ChatRoomView

### DIFF
--- a/src/converse-dragresize.js
+++ b/src/converse-dragresize.js
@@ -272,7 +272,7 @@
                     var div = document.createElement('div');
                     div.innerHTML = converse.templates.dragresize();
                     flyout.insertBefore(
-                        div.firstChild,
+                        div,
                         flyout.firstChild
                     );
                 }


### PR DESCRIPTION
The ChatRoomView renderDragResizeHandles is only rendering the top resize handle (`<div class="dragresize dragresize-top"></div>`). the insert was only inserting the first child of the dragresize template, which has 3 children. Modified to insert the whole the div that the dragresize template gets inserted into.
