### PR TITLE
Allow setting contact attrs on chats.open

### DIFF
--- a/src/converse-api.js
+++ b/src/converse-api.js
@@ -106,20 +106,20 @@
             }
         },
         'chats': {
-            'open': function (jids) {
+            'open': function (jids, attrs) {
                 var chatbox;
                 if (_.isUndefined(jids)) {
                     converse.log("chats.open: You need to provide at least one JID", "error");
                     return null;
                 } else if (_.isString(jids)) {
                     chatbox = converse.wrappedChatBox(
-                        converse.chatboxes.getChatBox(jids, true).trigger('show')
+                        converse.chatboxes.getChatBox(jids, true, attrs).trigger('show')
                     );
                     return chatbox;
                 }
                 return _.map(jids, function (jid) {
                     chatbox = converse.wrappedChatBox(
-                        converse.chatboxes.getChatBox(jid, true).trigger('show')
+                        converse.chatboxes.getChatBox(jid, true, attrs).trigger('show')
                     );
                     return chatbox;
                 });


### PR DESCRIPTION
@jcbrand You reverted [parts of my non roster chat commit](https://github.com/jcbrand/converse.js/commit/25d9880f9edc301ce391459d4959dbb8ae0991ff#diff-7a8f4a801d017f221fa2ccba7b7ddcb6L109). Is there a reason for this?

This commit reapplies these parts. I need to be able to set contact attrs with `chats.open`. I use this to set the `fullname` which is missing if the contact is not in the roster.