### PR TITLE
Fixes the duplication bug in adding contact

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -64,6 +64,7 @@
   New configuration setting:
   [muc_show_join_leave](https://conversejs.org/docs/html/configuration.html#muc-show-join-leave)
 - #366 Show the chat room occupant's JID in the tooltip (if you're allowed to see it). [jcbrand]
+- #585 Fixes the duplication bug due to case sensivity in adding contacts [saganshul]
 - #610, #785 Add presence priority handling [w3host, jcbrand]
 - #620 `auto_away` shouldn't change the user's status if it's set to `dnd`. [jcbrand]
 - #694 The `notification_option` wasn't being used consistently. [jcbrand]

--- a/spec/controlbox.js
+++ b/spec/controlbox.js
@@ -1087,6 +1087,34 @@
             // XXX: Awaiting more tests, close it again for now...
             panel.$el.find('a.toggle-xmpp-contact-form').click();
         }));
+
+        it("can be used to add contact and it checks for case-sensivity", mock.initConverse(function (_converse) {
+            spyOn(_converse, 'emit');
+            spyOn(_converse.rosterview, 'update').andCallThrough();
+            runs(function () {
+                test_utils.openControlBox();
+                // Adding two contacts one with Capital initials and one with small initials of same JID (Case sensitive check)
+                _converse.roster.create({
+                    jid: mock.pend_names[0].replace(/ /g,'.').toLowerCase() + '@localhost',
+                    subscription: 'none',
+                    ask: 'subscribe',
+                    fullname: mock.pend_names[0]
+                });
+                _converse.roster.create({
+                    jid: mock.pend_names[0].replace(/ /g,'.') + '@localhost',
+                    subscription: 'none',
+                    ask: 'subscribe',
+                    fullname: mock.pend_names[0]
+                });
+            });
+            waits(300);
+            runs(function () {
+                // Checking that only one entry is created because both JID is same (Case sensitive check)
+                expect(_converse.rosterview.$el.find('dd:visible').length).toBe(1);
+                expect(_converse.rosterview.update).toHaveBeenCalled();
+            });
+        }));
+
     });
 
     describe("The Controlbox Tabs", function () {

--- a/src/converse-core.js
+++ b/src/converse-core.js
@@ -778,7 +778,7 @@
 
             initialize: function (attributes) {
                 var jid = attributes.jid;
-                var bare_jid = Strophe.getBareJidFromJid(jid);
+                var bare_jid = Strophe.getBareJidFromJid(jid).toLowerCase();
                 var resource = Strophe.getResourceFromJid(jid);
                 attributes.jid = bare_jid;
                 this.set(_.assignIn({
@@ -887,7 +887,7 @@
                 resources[resource] = {
                     'priority': priority,
                     'status': chat_status,
-                    'timestamp': timestamp 
+                    'timestamp': timestamp
                 };
                 var changed = {'resources': resources};
                 var hpr = this.getHighestPriorityResource();


### PR DESCRIPTION
## Description

This PR fixes the bug mentioned in #585. Bug is on adding contact say **Singhal@conversejs.org** after **singhal@conversejs.org**(which are both same) gets add to contact list. This behaviour is bug because singhal@conversejs.org and Singhal@conversejs.org both are technically same JID.  Hence converting the JID to lowercase anytime user add a contact will solve this issue.

## Reviewer
@jcbrand 
 
## Screenshots
![11f3a944938e934847b04b94a4308510](https://cloud.githubusercontent.com/assets/11960067/23577546/176cabfe-00e8-11e7-8ac3-73319e8f7146.png)
![0b8c6f5d2cd5159347545903da151e48](https://cloud.githubusercontent.com/assets/11960067/23577548/1c999484-00e8-11e7-8b01-0f6346393cbd.png)
![584f6587390942d79f9dee6c59ac5a0d](https://cloud.githubusercontent.com/assets/11960067/23577552/20be928a-00e8-11e7-8ef9-a45ea891d597.png)


