### PR TITLE
Fixes the bug in displaying chat status during private chat (Message carbons)

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -72,6 +72,7 @@
 - #585 Fixes the duplication bug due to case sensivity in adding contacts [saganshul]
 - #610, #785 Add presence priority handling [w3host, jcbrand]
 - #620 `auto_away` shouldn't change the user's status if it's set to `dnd`. [jcbrand]
+- #628 Fixes the bug in displaying chat status during private chat (Message carbons) [saganshul]
 - #694 The `notification_option` wasn't being used consistently. [jcbrand]
 - #745 New config option [priority](https://conversejs.org/docs/html/configuration.html#priority) [jcbrand]
 - #770 Allow setting contact attrs on chats.open [Ape]

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -4,6 +4,7 @@
 
 - #806 The `_converse.listen` API event listeners aren't triggered. [jcbrand]
 - #807 Error: Plugin "converse-dragresize" tried to override HeadlinesBoxView but it's not found. [jcbrand]
+- #628 Fixes the bug in displaying chat status during private chat (Message carbons) [saganshul]
 
 ## 3.0.0 (2017-03-05)
 
@@ -72,7 +73,6 @@
 - #585 Fixes the duplication bug due to case sensivity in adding contacts [saganshul]
 - #610, #785 Add presence priority handling [w3host, jcbrand]
 - #620 `auto_away` shouldn't change the user's status if it's set to `dnd`. [jcbrand]
-- #628 Fixes the bug in displaying chat status during private chat (Message carbons) [saganshul]
 - #694 The `notification_option` wasn't being used consistently. [jcbrand]
 - #745 New config option [priority](https://conversejs.org/docs/html/configuration.html#priority) [jcbrand]
 - #770 Allow setting contact attrs on chats.open [Ape]

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -4,7 +4,7 @@
 
 - #806 The `_converse.listen` API event listeners aren't triggered. [jcbrand]
 - #807 Error: Plugin "converse-dragresize" tried to override HeadlinesBoxView but it's not found. [jcbrand]
-- #628 Fixes the bug in displaying chat status during private chat (Message carbons) [saganshul]
+- #628 Fixes the bug in displaying chat status during private chat [saganshul]
 
 ## 3.0.0 (2017-03-05)
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -2,9 +2,9 @@
 
 ## 3.0.1 (Unreleased)
 
+- #628 Fixes the bug in displaying chat status during private chat. [saganshul]
 - #806 The `_converse.listen` API event listeners aren't triggered. [jcbrand]
 - #807 Error: Plugin "converse-dragresize" tried to override HeadlinesBoxView but it's not found. [jcbrand]
-- #628 Fixes the bug in displaying chat status during private chat [saganshul]
 
 ## 3.0.0 (2017-03-05)
 

--- a/spec/chatbox.js
+++ b/spec/chatbox.js
@@ -892,7 +892,7 @@
                     expect(chatbox.messages.length).toEqual(1);
                     var msg_obj = chatbox.messages.models[0];
                     expect(msg_obj.get('message')).toEqual(msgtext);
-                    expect(msg_obj.get('fullname')).toEqual(mock.cur_names[5]);
+                    expect(msg_obj.get('fullname')).toEqual(_converse.xmppstatus.get('fullname'));
                     expect(msg_obj.get('sender')).toEqual('me');
                     expect(msg_obj.get('delayed')).toEqual(false);
                     // Now check that the message appears inside the chatbox in the DOM

--- a/src/converse-core.js
+++ b/src/converse-core.js
@@ -1369,7 +1369,7 @@
             getMessageAttributes: function (message, delay, original_stanza) {
                 delay = delay || message.querySelector('delay');
                 var type = message.getAttribute('type'),
-                    body, stamp, time, sender, from;
+                    body, stamp, time, sender, from, fullname;
 
                 if (type === 'error') {
                     body = _.propertyOf(message.querySelector('error text'))('textContent');
@@ -1377,7 +1377,6 @@
                     body = _.propertyOf(message.querySelector('body'))('textContent');
                 }
                 var delayed = !_.isNull(delay),
-                    fullname = this.get('fullname'),
                     is_groupchat = type === 'groupchat',
                     chat_state = message.getElementsByTagName(_converse.COMPOSING).length && _converse.COMPOSING ||
                         message.getElementsByTagName(_converse.PAUSED).length && _converse.PAUSED ||
@@ -1390,9 +1389,6 @@
                 } else {
                     from = Strophe.getBareJidFromJid(message.getAttribute('from'));
                 }
-                if (_.isEmpty(fullname)) {
-                    fullname = from;
-                }
                 if (delayed) {
                     stamp = delay.getAttribute('stamp');
                     time = stamp;
@@ -1401,8 +1397,10 @@
                 }
                 if ((is_groupchat && from === this.get('nick')) || (!is_groupchat && from === _converse.bare_jid)) {
                     sender = 'me';
+                    fullname = _converse.xmppstatus.get('fullname') || from;
                 } else {
                     sender = 'them';
+                    fullname = this.get('fullname') || from;
                 }
                 return {
                     'type': type,


### PR DESCRIPTION
## Description
This PR fixes the bug mentioned in #628 
The bug was actually in assignment of `fullname` variable. It should always be set to `from`.
So what was happening `fullname` variable in private chat(message carbons enabled) was getting set to `this.get('fullname)'` which is actually not the correct `fullname` in this case and due to this variable is set, `_.isEmpty(fullname)` results into `false` and this operation `fullname = from;` fail to carry out.

Hence the perfect fix should be to just to initialise it first and then set it to `from` .

## Reviewer
@jcbrand 

## Screenshots
![1](https://cloud.githubusercontent.com/assets/11960067/23581993/89e59cb4-0146-11e7-89ce-a94dcb891537.png)
![2](https://cloud.githubusercontent.com/assets/11960067/23581994/89e5a6f0-0146-11e7-9f15-67f5a8816188.jpg)
![3](https://cloud.githubusercontent.com/assets/11960067/23581995/89e67fe4-0146-11e7-82f1-a2732503f50e.png)

## Explaination of screenshot(for testing):
So to test I registered with two accounts on conversejs.org -
* singhal@conversejs.org
* anshul@conversejs.org.
In screenshots - First block is of singhal@conversejs.org and rest two are of anshul@conversejs.org(to test message carbons - two end points). I used in-cognitive mode of google chrome
In first image: singhal@conversejs.org is typing and the same information is reflected in other two.
In second image: first(middle block) anshul@conversejs.org is typing and the same info is reflected which was previously a bug because block 3 was shows singhal@conversejs.org which was a bug. Hence after this fix this is not a case.

I checked this fix with group chat also and it is working correctly.

