### PR TITLE
Fixed typing status for typing from different device

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -4,7 +4,8 @@
 
 - #585 Duplicate contact created due to JID case sensivity [saganshul]
 - #628 Fixes the bug in displaying chat status during private chat. [saganshul]
-- #797 Time format made configurable. [smitbose]
+- #628 Changes the message displayed while typing from a different resource of the same user. [smitbose]
+- #675 Time format made configurable. [smitbose]
 - #806 The `_converse.listen` API event listeners aren't triggered. [jcbrand]
 - #807 Error: Plugin "converse-dragresize" tried to override HeadlinesBoxView but it's not found. [jcbrand]
 

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -376,10 +376,20 @@
 
                 handleChatStateMessage: function (message) {
                     if (message.get('chat_state') === _converse.COMPOSING) {
-                        this.showStatusNotification(message.get('fullname')+' '+__('is typing'));
+                        if(message.get('sender') === 'me') {
+                            this.showStatusNotification(__('Typing from another device'));
+                        }
+                        else {
+                            this.showStatusNotification(message.get('fullname')+' '+__('is typing'));
+                        }
                         this.clear_status_timeout = window.setTimeout(this.clearStatusNotification.bind(this), 30000);
                     } else if (message.get('chat_state') === _converse.PAUSED) {
-                        this.showStatusNotification(message.get('fullname')+' '+__('has stopped typing'));
+                        if(message.get('sender') === 'me') {
+                            this.showStatusNotification(__('Stopped typing on the other device'));
+                        }
+                        else {
+                            this.showStatusNotification(message.get('fullname')+' '+__('has stopped typing'));
+                        }
                     } else if (_.includes([_converse.INACTIVE, _converse.ACTIVE], message.get('chat_state'))) {
                         this.$content.find('div.chat-event').remove();
                     } else if (message.get('chat_state') === _converse.GONE) {


### PR DESCRIPTION
This fixes the bug #628 . 

While writing from another device, logged in with the same JID, the current code shows a different user is typing. This commit fixes that to show status message "Typing from another device" and "Stopped typing on the other device" in those cases. 
It however leaves the previous behaviour unchanged in case of other users. 
![screenshot from 2017-03-05 02-12-16](https://cloud.githubusercontent.com/assets/10517141/23582149/f3af64ba-0149-11e7-94f7-7992a84bff5b.png)
![screenshot from 2017-03-05 02-10-27](https://cloud.githubusercontent.com/assets/10517141/23582150/f9b4231e-0149-11e7-9600-9a78787b5c6d.png)
