### PR TITLE
Implemented auto fetching of registration form for default XMPP domain

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,8 @@
 - #628 Fixes the bug in displaying chat status during private chat. [saganshul]
 - #628 Changes the message displayed while typing from a different resource of the same user. [smitbose]
 - #675 Time format made configurable. [smitbose]
+- #704 Automatic fetching of registration form when [registration_domain](https://conversejs.org/
+docs/html/configurations.html#registration-domain) is set. [smitbose]
 - #806 The `_converse.listen` API event listeners aren't triggered. [jcbrand]
 - #807 Error: Plugin "converse-dragresize" tried to override HeadlinesBoxView but it's not found. [jcbrand]
 - #820 Inconsistency in displaying room features. [jcbrand]

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -483,6 +483,14 @@ JIDs with other domains are still allowed but need to be provided in full.
 To specify only one domain and disallow other domains, see the `locked_domain`_
 option.
 
+registration_domain
+-------------------
+
+* Default: ``''``
+
+Specify a domain name for which the registration form will be fetched automatically,
+without the user having to enter any XMPP server domain name.
+
 default_state
 -------------
 

--- a/src/converse-core.js
+++ b/src/converse-core.js
@@ -256,6 +256,7 @@
             password: undefined,
             prebind_url: null,
             priority: 0,
+            registration_domain: '',
             rid: undefined,
             roster_groups: true,
             show_only_online_users: false,

--- a/src/templates/register_panel.html
+++ b/src/templates/register_panel.html
@@ -1,7 +1,14 @@
 <form id="converse-register" class="pure-form converse-form">
     <span class="reg-feedback"></span>
     <label>{{{label_domain}}}</label>
-    <input type="text" name="domain" placeholder="{{{domain_placeholder}}}">
+    {[ if (default_domain) { ]}
+    	<label>{{{default_domain}}}</label>
+    {[ } ]}
+    {[ if (!default_domain) { ]}
+    	<input type="text" name="domain" placeholder="{{{domain_placeholder}}}">
+    {[ } ]}
     <p class="form-help">{{{help_providers}}} <a href="{{{href_providers}}}" class="url" target="_blank" rel="noopener">{{{help_providers_link}}}</a>.</p>
-    <input class="pure-button button-primary" type="submit" value="{{{label_register}}}">
+    {[ if (!default_domain) { ]}
+    	<input class="pure-button button-primary" type="submit" value="{{{label_register}}}">
+    {[ } ]}
 </form>

--- a/src/templates/registration_request.html
+++ b/src/templates/registration_request.html
@@ -1,3 +1,5 @@
 <span class="spinner login-submit"/>
 <p class="info">{{{info_message}}}</p>
-<button class="pure-button button-cancel hor_centered">{{{cancel}}}</button>
+{[ if (cancel) { ]}
+	<button class="pure-button button-cancel hor_centered">{{{cancel}}}</button>
+{[ } ]}


### PR DESCRIPTION
This is an implementation of the feature requested in #704 .

A new configuration variable `enable_default_domain` which when set to true, the registration form on initiation reads the domain from `default_domain_name` and fetches the registration form for the same. It doesn't allow the user to input the domain or cancel the fetched registration form by any means.

@jcbrand please review the codes, while I'm moving on to adding documentation for the added configurations, as well as updating changelog. I don't think any specific tests can be written for this because the behaviour is same as the mainline sequence of taking user input and fetching registraion form, except with forced event triggers.