### PR TITLE
support opening chat in minimized mode initially

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -17,6 +17,7 @@
 - Bugfix: MUC user's nickname wasn't being shown in HTML5 notification messages. [jcbrand]
 - Bugfix: OTR meta-messages were being shown in HTML5 notifications. [jcbrand]
 - CSS fix: Icon lock wasn't showing. [jcbrand]
+- #626 Open chat minimised [novokrest]
 - #842 Persistent muc room creation not working [jcbrand]
 - #848 OTR doesn't start when `cache_otr_key` is set to `true`. [jcbrand]
 - #849 `TypeError: _converse.i18n.locale_data is undefined` when reconnecting. [jcbrand]

--- a/spec/chatbox.js
+++ b/spec/chatbox.js
@@ -122,6 +122,22 @@
                 });
             }));
 
+            it("can be opened in minimized mode initially", mock.initConverse(function(_converse) {
+                test_utils.createContacts(_converse, 'current');
+
+                var sender_jid = mock.cur_names[0].replace(/ /g,'.').toLowerCase() + '@localhost';
+                var chat = _converse.api.chats.open(sender_jid, {
+                    minimized: true
+                });
+
+                var chatBoxView = _converse.chatboxviews.get(sender_jid);
+                expect(chatBoxView.$el.is(':visible')).toBeFalsy();
+
+                var minimized_chat = _converse.minimized_chats.get(sender_jid);
+                expect(minimized_chat).toBeTruthy();
+                expect(minimized_chat.$el.is(':visible')).toBeTruthy();
+            }));
+
             it("is focused if its already open and you click on its corresponding roster item", mock.initConverseWithAsync(function (done, _converse) {
                 test_utils.createContacts(_converse, 'current');
                 test_utils.openControlBox();

--- a/src/converse-minimize.js
+++ b/src/converse-minimize.js
@@ -96,9 +96,11 @@
 
                 _show: function () {
                     var _converse = this.__super__._converse;
-                    this.__super__._show.apply(this, arguments);
                     if (!this.model.get('minimized')) {
+                        this.__super__._show.apply(this, arguments);
                         _converse.chatboxviews.trimChats(this);
+                    } else {
+                        this.minimize();
                     }
                 },
 


### PR DESCRIPTION
**Converse.js** already supports opening chat in minimized (trimmed) mode by specifying **minimized** attribute: **_converse.api.chats.open(jid, { minimized: true })**. But current implementation has incorrect behavior: if you pass **minimized: true** to **chats.open()**, then **both** normal and trimmed chatboxes will be opened. 
Proposed PR fixes this bug.