### PR TITLE
#567 Unreaded message count reset on page load 

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -9,6 +9,7 @@
 - Show unread messages next to roster contacts. [jcbrand]
 - API change: the `message` event now returns a data object with `stanza` and
   `chatbox` attributes, instead of just the stanza. [jcbrand]
+- #567 Unreaded message count reset on page load [novokrest]
 
 ## 3.0.2 (2017-04-23)
 

--- a/src/converse-minimize.js
+++ b/src/converse-minimize.js
@@ -339,12 +339,12 @@
                 },
 
                 clearUnreadMessagesCounter: function () {
-                    this.model.set({'num_unread': 0});
+                    this.model.save({'num_unread': 0});
                     this.render();
                 },
 
                 updateUnreadMessagesCounter: function () {
-                    this.model.set({'num_unread': this.model.get('num_unread') + 1});
+                    this.model.save({'num_unread': this.model.get('num_unread') + 1});
                     this.render();
                 },
 
@@ -462,7 +462,7 @@
                     var ls = this.model.pluck('num_unread'),
                         count = 0, i;
                     for (i=0; i<ls.length; i++) { count += ls[i]; }
-                    this.toggleview.model.set({'num_unread': count});
+                    this.toggleview.model.save({'num_unread': count});
                     this.render();
                 }
             });


### PR DESCRIPTION
@jcbrand Hi! I've made some research on this issue and it seems that possible solution is just **always** to save unread message count on server and fetch it when the page is (re)loaded (what has already been done).