### PR TITLE
#591 Unread message counter is reset when the chatbox is closed 

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -10,6 +10,7 @@
 - API change: the `message` event now returns a data object with `stanza` and
   `chatbox` attributes, instead of just the stanza. [jcbrand]
 - #567 Unreaded message count reset on page load [novokrest]
+- #591 Unread message counter is reset when the chatbox is closed [novokrest]
 - Remove all inline CSS to comply with strict Content-Security-Policy headers [mathiasertl]
 
 ## 3.0.2 (2017-04-23)

--- a/src/converse-chatview.js
+++ b/src/converse-chatview.js
@@ -151,7 +151,7 @@
 
                 fetchMessages: function () {
                     this.model.messages.fetch({
-                        'add': true,
+                        'add': false,
                         'success': this.afterMessagesFetched.bind(this),
                         'error': this.afterMessagesFetched.bind(this),
                     });


### PR DESCRIPTION
@jcbrand Hi! Solution turned out to be quite simple and I decide to make separate PR for fixing just this issue.

P.S. And, as I've already mentioned, I've found some inconsistent handling of new incoming messages that cause information about unread messages is out of sync in different parts of GUI. 

Problem scenario:
1. User opens chat
2. User scrolls up so that new message will be not visible
3. User receives message: indicator of 'new unread messages' are appeared at the bottom of chatbox
4. Roster view does not show unread messages count (**bug**)
5. User minimizes chatbox: there is no indicator of unread messages count (**bug**)

Now I continue working on it and (as soon as possible) will create separate PR.
