### PR TITLE
No need to require NPM in a file executed by NPM.

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 3.1.0 (Unreleased)
 
+- Removed the redundant `npm` module as a dev-dependency.
 - New non-core plugin `converse-singleton` which ensures that no more than
   one chat is visible at any given time. Used in the mobile build:
   `converse-mobile.js` and makes the unread messages counter possible there.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "lodash": "^4.17.4",
     "lodash-template-loader": "^2.0.0",
     "moment": "~2.18.1",
-    "npm": "^4.1.1",
     "otr": "0.2.16",
     "phantomjs-prebuilt": "~2.1.14",
     "pluggable.js": "1.0.0",


### PR DESCRIPTION
This PR removes 'npm' as a named dev-dependency for the project. The requirement of NPM as a dependency seems redundant.

The minimum version definition appears to add little value, especially since (at least for me) having the requirement introduces this build problem.

```
vagrant@vagrant:/vagrant$ npm install npm
converse.js@3.0.2 /vagrant
`-- (empty)

npm ERR! Linux 4.8.0-49-generic
npm ERR! argv "/usr/bin/nodejs" "/usr/bin/npm" "install" "npm"
npm ERR! node v7.10.0
npm ERR! npm  v4.2.0
npm ERR! path /vagrant/node_modules/npm/node_modules/node-gyp/node_modules/nopt/bin/nopt.js
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall chmod

npm ERR! enoent ENOENT: no such file or directory, chmod '/vagrant/node_modules/npm/node_modules/node-gyp/node_modules/nopt/bin/nopt.js'
npm ERR! enoent ENOENT: no such file or directory, chmod '/vagrant/node_modules/npm/node_modules/node-gyp/node_modules/nopt/bin/nopt.js'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! Please include the following file with any support request:
npm ERR!     /home/vagrant/.npm/_logs/2017-05-15T19_10_19_041Z-debug.log
```