### PR TITLE
Converse ryzen 894

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@
 - #754 Show unread messages next to roster contacts. [jcbrand]
 - #864 Remove all inline CSS to comply with strict Content-Security-Policy headers [mathiasertl]
 - #873 Inconsistent unread messages count updating [novokrest]
+- #894 Room affiliation lost when connection jid and room presence jid are of different case [Rayzen]
 
 ## 3.0.2 (2017-04-23)
 

--- a/src/converse-muc.js
+++ b/src/converse-muc.js
@@ -1717,7 +1717,7 @@
                     var item = sizzle('x[xmlns="'+Strophe.NS.MUC_USER+'"] item', pres).pop();
                     if (_.isNil(item)) { return; }
                     var jid = item.getAttribute('jid');
-                    if (Strophe.getBareJidFromJid(jid) === _converse.bare_jid) {
+                    if (Strophe.getBareJidFromJid(jid).toLowerCase() === _converse.bare_jid.toLowerCase()) {
                         var affiliation = item.getAttribute('affiliation');
                         var role = item.getAttribute('role');
                         if (affiliation) {


### PR DESCRIPTION
As discussed in Issue #894 the methosSaveAffiliationAndRole compared strictly the bare jid bound to connection and the bare jid retrieved from XMPP presence message.
Fixed by converting both bare jid to lowe case.
