### PR TITLE
Fix regarding ChatRoomView.getDefaultNickName() and muc_nickname_from_jid

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Bugfixes
 - Various IE11 fixes.
 - Translations written as template literals [aren't parsed properly by xgettext](https://savannah.gnu.org/bugs/?50920).
+- Fix regarding ChatRoomView.getDefaultNickName() and muc_nickname_from_jid
 
 ## 3.2.0 (2017-08-09)
 

--- a/src/converse-muc.js
+++ b/src/converse-muc.js
@@ -1571,7 +1571,7 @@
                     if (_converse.muc_nickname_from_jid) {
                         // We try to enter the room with the node part of
                         // the user's JID.
-                        this.join(Strophe.unescapeNode(Strophe.getNodeFromJid(_converse.bare_jid)));
+                        this.join(this.getDefaultNickName());
                     } else {
                         this.renderNicknameForm(message);
                     }


### PR DESCRIPTION
Allows plugins to override nickname when muc_nickname_from_jid is true.