### PR TITLE
IM is not a french word / « ouvrir » means « to open »

### DIFF
--- a/locale/fr/LC_MESSAGES/converse.po
+++ b/locale/fr/LC_MESSAGES/converse.po
@@ -419,7 +419,7 @@ msgstr "Aucun utilisateur trouvé"
 
 #: dist/converse-no-dependencies.js:16782
 msgid "Toggle chat"
-msgstr "Ouvrir IM"
+msgstr "Ouvrir la discussion"
 
 #: dist/converse-no-dependencies.js:18260
 msgid "This room is not anonymous"
@@ -780,7 +780,7 @@ msgstr "Non-anonyme"
 
 #: dist/converse-no-dependencies.js:19993
 msgid "Open"
-msgstr "Ouvrir"
+msgstr "Ouvert"
 
 #: dist/converse-no-dependencies.js:19994
 msgid "Password protected"


### PR DESCRIPTION
Simple locale fix, I guess I do not have to provide test and such.

Replacing « IM » with what is used in the rest of the file for « chat », and fixing a typo on « open » (which has to be translated by « ouvert », not « ouvrir », which means « to open ».
