### PR TITLE
Fixed error building DOM toggle_chats.html span.unread-message-count class attribute

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@
   Otherwise connected contacts might not get your presence updates.
 - The way the archive ID of a MAM message is specified, has changed.
   See https://xmpp.org/extensions/xep-0313.html#archives_id
+- Fixed error building DOM toggle_chats.html span.unread-message-count class attribute
 
 ### New Features
 - #314 Add support for opening chat rooms with a URL fragment such as `#converse/room?jid=room@domain`

--- a/src/templates/toggle_chats.html
+++ b/src/templates/toggle_chats.html
@@ -1,4 +1,4 @@
 {{{o.Minimized}}} <span id="minimized-count">({{{o.num_minimized}}})</span>
 <span class="unread-message-count
-    {[ if (!o.num_unread) { ]} unread-message-count-hidden {[ } ]}
+    {[ if (!o.num_unread) { ]} unread-message-count-hidden {[ } ]}"
     href="#">{{{o.num_unread}}}</span>


### PR DESCRIPTION
toggle_chats.html template was broken in the construction of span.unread-message-count class attribute.
A missing `"` was causing the making of the DOM like so: 
`<span class="unread-message-count href=" #">...</span>`
Please note the `href=` class and the absence of the `href` attribute (see attachment).

![image](https://user-images.githubusercontent.com/881393/33557879-c3b5bf2e-d908-11e7-97fe-0849e1f88ff0.png)
