### PR TITLE
Add backbone.overview as a dependency for the chatboxes module

### DIFF
--- a/src/converse-chatboxes.js
+++ b/src/converse-chatboxes.js
@@ -7,7 +7,7 @@
 /*global define */
 
 (function (root, factory) {
-    define(["converse-core"], factory);
+    define(["converse-core", "backbone.overview"], factory);
 }(this, function (converse) {
     "use strict";
     const { Backbone, Promise, Strophe, b64_sha1, moment, utils, _ } = converse.env;


### PR DESCRIPTION
I'm currently working on using Converse.js as components within a webpack based application. I'm going to share more results later.

I faced a problem, that `converse-chatboxes.js` references `Backbone.Overview` [here](https://github.com/cmrd-senya/converse.js/blob/c4c16d636d511570411826529c81c2c5d5fae74b/src/converse-chatboxes.js#L409). It is not a problem for the standard build because it somehow got resolved properly, but when I import Converse.js from a Webpack application as a library, this file don't load `Backbone.Overview` and I got `Backbone` defined, but `Backbone.Overview` is undefined. For me it works when I add `backbone.overview` reference to the dependency list of that module.

It seems that it doesn't change the usual build so I think it is safe to merge: it only makes things better with webpack while everything else don't get worse.