### PR TITLE
send emojis as unicode also in MUCs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Avoid `eval` (via `_.template` from lodash).
 - Don't show bookmark toggles when PEP bookmarking not supported by the XMPP server.
 - Add LibreJS support
+- Emojis are now sent in unicode instead of short names (also in MUCs)
 
 ### Bugfixes
 

--- a/src/converse-muc.js
+++ b/src/converse-muc.js
@@ -13,6 +13,7 @@
     define([
             "form-utils",
             "converse-core",
+            "emojione",
             "lodash.fp",
             "tpl!chatarea",
             "tpl!chatroom",
@@ -44,6 +45,7 @@
 }(this, function (
             u,
             converse,
+            emojione,
             fp,
             tpl_chatarea,
             tpl_chatroom,
@@ -969,6 +971,7 @@
                      * Parameters:
                      *  (String) text: The message text to be sent.
                      */
+                    text = emojione.shortnameToUnicode(text)
                     const msgid = _converse.connection.getUniqueId();
                     const msg = $msg({
                         to: this.model.get('jid'),


### PR DESCRIPTION
I recognized that https://github.com/jcbrand/converse.js/pull/977 does not work in MUCs. This PR fixes it.